### PR TITLE
fix tox tests and remove idna requirement.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 PyYAML>=3.12
 requests>=2.12.4
-idna<2.6,>=2.5
+pycrypto

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ if version_info[:3] < (2, 7, 9):
             requires.remove(item)
             requires.append('requests[security]')
 
+if version_info[:3] < (2, 7, 0):
+    requires.insert(0, 'idna<2.6,>=2.5')
+
 setup(
     name='qingstor-sdk',
     version=__version__,

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,14 @@ from qingstor.sdk import __version__
 
 ROOT = os.path.dirname(__file__)
 
-requires = ['requests', 'PyYAML', 'idna<2.7,>=2.5', 'urllib3', 'pycrypto']
+with open('requirements.txt') as fp:
+    requires = [item.strip() for item in fp.readlines()]
 
 if version_info[:3] < (2, 7, 9):
-    requires[0] = "requests[security]"
+    for item in requires:
+        if item.startswith('requests'):
+            requires.remove(item)
+            requires.append('requests[security]')
 
 setup(
     name='qingstor-sdk',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35
+envlist = py26,py27,py33,py34,py35,py36,py37
 # Comment to build sdist and install into virtualenv
 # This is helpful to test installation but takes extra time
 skipsdist = True
@@ -9,5 +9,6 @@ commands =
     nosetests
 deps =
     nose
-    pyyaml
-    requests
+    assertpy
+    mock
+    -rrequirements.txt


### PR DESCRIPTION
其实我只是想删除对 `idna` 的依赖，因为 qingstor-sdk-python 并没有直接使用 `idna` ，应该是 `request` 内部用了 `idna`，所以，requirements.txt 中不应该指定对 `idna` 的依赖。（删除 idna 的依赖是因为这里指定的版本 和 我代码其它地方用 idna 版本不一致）

但，删除 `idna` 依赖后，发现 `tox` 没法运行，所以又修复了 `tox.ini`

后来发现 setup.py 中又单独列出了 Python 依赖包，那么就没必要用 requirements.txt 了。用了 requirements.txt ，setup.py 中也应该使用它，所以，修改了下 setup.py。